### PR TITLE
Update DKMS for the generic-4.7.x branch.

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -2,7 +2,7 @@ PACKAGE_NAME=rtlwifi
 PACKAGE_VERSION=1.0.0
 MAKE='make KVER=$kernelver'
 REMAKE_INITRD=yes
-BUILD_EXCLUSIVE_KERNEL=^4.3.x
+BUILD_EXCLUSIVE_KERNEL=^4.7.*
 
 BUILT_MODULE_NAME[0]=rtlwifi
 BUILT_MODULE_NAME[1]=rtl8192c_common
@@ -11,10 +11,6 @@ BUILT_MODULE_NAME[3]=rtl8192ce
 BUILT_MODULE_NAME[4]=rtl8192de
 BUILT_MODULE_NAME[5]=rtl8188ee
 BUILT_MODULE_NAME[6]=rtl8192cu
-BUILT_MODULE_NAME[7]=rtl8723ae
-BUILT_MODULE_NAME[8]=rtl8723be
-BUILT_MODULE_NAME[9]=rtl8723com
-BUILT_MODULE_NAME[10]=rtl8821ae
 
 BUILT_MODULE_LOCATION[0]=./
 BUILT_MODULE_LOCATION[1]=rtl8192c/
@@ -23,10 +19,6 @@ BUILT_MODULE_LOCATION[3]=rtl8192ce/
 BUILT_MODULE_LOCATION[4]=rtl8192de/
 BUILT_MODULE_LOCATION[5]=rtl8188ee/
 BUILT_MODULE_LOCATION[6]=rtl8192cu/
-BUILT_MODULE_LOCATION[7]=rtl8723ae/
-BUILT_MODULE_LOCATION[8]=rtl8723be/
-BUILT_MODULE_LOCATION[9]=rtl8723com/
-BUILT_MODULE_LOCATION[10]=rtl8821ae/
 
 DEST_MODULE_LOCATION[0]=/kernel/drivers/net/wireless/rtlwifi/
 DEST_MODULE_LOCATION[1]=/kernel/drivers/net/wireless/rtlwifi/rtl8192c/
@@ -35,9 +27,5 @@ DEST_MODULE_LOCATION[3]=/kernel/drivers/net/wireless/rtlwifi/rtl8192ce/
 DEST_MODULE_LOCATION[4]=/kernel/drivers/net/wireless/rtlwifi/rtl8192de/
 DEST_MODULE_LOCATION[5]=/kernel/drivers/net/wireless/rtlwifi/rtl8188ee/
 DEST_MODULE_LOCATION[6]=/kernel/drivers/net/wireless/rtlwifi/rtl8192cu/
-DEST_MODULE_LOCATION[7]=/kernel/drivers/net/wireless/rtlwifi/rtl8723ae/
-DEST_MODULE_LOCATION[8]=/kernel/drivers/net/wireless/rtlwifi/rtl8723be/
-DEST_MODULE_LOCATION[9]=/kernel/drivers/net/wireless/rtlwifi/rtl8723com/
-DEST_MODULE_LOCATION[10]=/kernel/drivers/net/wireless/rtlwifi/rtl8821ae/
 
 AUTOINSTALL=yes


### PR DESCRIPTION
This fixes two issues that prevented DKMS from being able to build the repo on the generic-4.7.x branch: the BUILD_EXCLUSIVE_KERNEL setting was incorrect, and the rtl{8723,8821} modules were stil listed, even though the Makefile no longer builds them.

I assume there may be similar issues on other branches, but haven't investigated very thoroughly (and can't roll those changes into a single PR anyway).