### PR TITLE
Fixes issue #123

### DIFF
--- a/rtl8188ee/pwrseqcmd.c
+++ b/rtl8188ee/pwrseqcmd.c
@@ -140,7 +140,7 @@ bool rtl88_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 					 "rtl88_hal_pwrseqcmdparsing(): PWR_CMD_END\n" );
 				return true;
 			default:
-				RT_ASSERT( false,
+				WARN_ONCE( false,
 					  "rtl88_hal_pwrseqcmdparsing(): Unknown CMD!!\n" );
 				break;
 			}


### PR DESCRIPTION
According to the https://github.com/torvalds/linux/commit/531940f9644da798f04382aeb5e8929295dfde61  RT_ASSERT was replaced by WARN_ONCE.