### PR TITLE
Updated path to wireless driver for rtl8192ce

### DIFF
--- a/rtl8192ce/Makefile
+++ b/rtl8192ce/Makefile
@@ -2,7 +2,7 @@
 CC = gcc
 KVER  := $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
-MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/realtek
 PWD := $(shell pwd)
 
 EXTRA_CFLAGS += -O2


### PR DESCRIPTION
The install script was previously installing it one directory too high.