### PR TITLE
Fix compilation error ( #153, #155, #157, #159 ) - use rtl_dbg rather than RT_TRACE

### DIFF
--- a/rtl8188ee/pwrseqcmd.c
+++ b/rtl8188ee/pwrseqcmd.c
@@ -67,7 +67,8 @@ bool rtl88_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 
 	do {
 		cmd = pwrcfgcmd[ary_idx];
-		RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+		
+		rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 			 "rtl88_hal_pwrseqcmdparsing(): offset(%#x), cut_msk(%#x), fab_msk(%#x),"
 			 "interface_msk(%#x), base(%#x), cmd(%#x), msk(%#x), val(%#x)\n",
 			 GET_PWR_CFG_OFFSET( cmd ),
@@ -84,11 +85,11 @@ bool rtl88_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 		    ( GET_PWR_CFG_INTF_MASK( cmd ) & interface_type ) ) {
 			switch ( GET_PWR_CFG_CMD( cmd ) ) {
 			case PWR_CMD_READ:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtl88_hal_pwrseqcmdparsing(): PWR_CMD_READ\n" );
 				break;
 			case PWR_CMD_WRITE: {
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtl88_hal_pwrseqcmdparsing(): PWR_CMD_WRITE\n" );
 				offset = GET_PWR_CFG_OFFSET( cmd );
 
@@ -103,7 +104,7 @@ bool rtl88_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 				}
 				break;
 			case PWR_CMD_POLLING:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtl88_hal_pwrseqcmdparsing(): PWR_CMD_POLLING\n" );
 				polling_bit = false;
 				offset = GET_PWR_CFG_OFFSET( cmd );
@@ -119,7 +120,7 @@ bool rtl88_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 						udelay( 10 );
 
 					if ( polling_count++ > max_polling_cnt ) {
-						RT_TRACE( rtlpriv, COMP_INIT,
+						rtl_dbg( rtlpriv, COMP_INIT,
 							 DBG_LOUD,
 							 "polling fail in pwrseqcmd\n" );
 						return false;
@@ -128,7 +129,7 @@ bool rtl88_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 
 				break;
 			case PWR_CMD_DELAY:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtl88_hal_pwrseqcmdparsing(): PWR_CMD_DELAY\n" );
 				if ( GET_PWR_CFG_VALUE( cmd ) == PWRSEQ_DELAY_US )
 					udelay( GET_PWR_CFG_OFFSET( cmd ) );
@@ -136,7 +137,7 @@ bool rtl88_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 					mdelay( GET_PWR_CFG_OFFSET( cmd ) );
 				break;
 			case PWR_CMD_END:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtl88_hal_pwrseqcmdparsing(): PWR_CMD_END\n" );
 				return true;
 			default:

--- a/rtl8723ae/pwrseqcmd.c
+++ b/rtl8723ae/pwrseqcmd.c
@@ -63,7 +63,7 @@ bool rtl_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 
 	do {
 		cfg_cmd = pwrcfgcmd[ary_idx];
-		RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+		rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 			"rtl_hal_pwrseqcmdparsing(): offset(%#x),cut_msk(%#x), famsk(%#x),"
 			"interface_msk(%#x), base(%#x), cmd(%#x), msk(%#x), value(%#x)\n",
 			GET_PWR_CFG_OFFSET( cfg_cmd ),
@@ -78,11 +78,11 @@ bool rtl_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 		    ( GET_PWR_CFG_INTF_MASK( cfg_cmd )&interface_type ) ) {
 			switch ( GET_PWR_CFG_CMD( cfg_cmd ) ) {
 			case PWR_CMD_READ:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					"rtl_hal_pwrseqcmdparsing(): PWR_CMD_READ\n" );
 				break;
 			case PWR_CMD_WRITE:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					"rtl_hal_pwrseqcmdparsing(): PWR_CMD_WRITE\n" );
 				offset = GET_PWR_CFG_OFFSET( cfg_cmd );
 
@@ -96,7 +96,7 @@ bool rtl_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 				rtl_write_byte( rtlpriv, offset, value );
 				break;
 			case PWR_CMD_POLLING:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					"rtl_hal_pwrseqcmdparsing(): PWR_CMD_POLLING\n" );
 				polling_bit = false;
 				offset = GET_PWR_CFG_OFFSET( cfg_cmd );
@@ -117,7 +117,7 @@ bool rtl_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 				} while ( !polling_bit );
 				break;
 			case PWR_CMD_DELAY:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					"rtl_hal_pwrseqcmdparsing(): PWR_CMD_DELAY\n" );
 				if ( GET_PWR_CFG_VALUE( cfg_cmd ) ==
 				    PWRSEQ_DELAY_US )
@@ -126,7 +126,7 @@ bool rtl_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 					mdelay( GET_PWR_CFG_OFFSET( cfg_cmd ) );
 				break;
 			case PWR_CMD_END:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtl_hal_pwrseqcmdparsing(): PWR_CMD_END\n" );
 				return true;
 			default:

--- a/rtl8723be/pwrseqcmd.c
+++ b/rtl8723be/pwrseqcmd.c
@@ -62,7 +62,7 @@ bool rtlbe_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 
 	do {
 		pwr_cfg_cmd = pwrcfgcmd[ary_idx];
-		RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+		rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 			 "rtlbe_hal_pwrseqcmdparsing(): "
 			 "offset(%#x),cut_msk(%#x), fab_msk(%#x),"
 			 "interface_msk(%#x), base(%#x), "
@@ -81,12 +81,12 @@ bool rtlbe_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 		    ( GET_PWR_CFG_INTF_MASK( pwr_cfg_cmd )&interface_type ) ) {
 			switch ( GET_PWR_CFG_CMD( pwr_cfg_cmd ) ) {
 			case PWR_CMD_READ:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtlbe_hal_pwrseqcmdparsing(): "
 					  "PWR_CMD_READ\n" );
 				break;
 			case PWR_CMD_WRITE:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtlbe_hal_pwrseqcmdparsing(): "
 					  "PWR_CMD_WRITE\n" );
 				offset = GET_PWR_CFG_OFFSET( pwr_cfg_cmd );
@@ -101,7 +101,7 @@ bool rtlbe_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 				rtl_write_byte( rtlpriv, offset, value );
 				break;
 			case PWR_CMD_POLLING:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtlbe_hal_pwrseqcmdparsing(): "
 					  "PWR_CMD_POLLING\n" );
 				b_polling_bit = false;
@@ -124,7 +124,7 @@ bool rtlbe_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 				} while ( !b_polling_bit );
 				break;
 			case PWR_CMD_DELAY:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtlbe_hal_pwrseqcmdparsing(): "
 					 "PWR_CMD_DELAY\n" );
 				if ( GET_PWR_CFG_VALUE( pwr_cfg_cmd ) ==
@@ -134,7 +134,7 @@ bool rtlbe_hal_pwrseqcmdparsing( struct rtl_priv *rtlpriv, u8 cut_version,
 					mdelay( GET_PWR_CFG_OFFSET( pwr_cfg_cmd ) );
 				break;
 			case PWR_CMD_END:
-				RT_TRACE( rtlpriv, COMP_INIT, DBG_TRACE,
+				rtl_dbg( rtlpriv, COMP_INIT, DBG_TRACE,
 					 "rtlbe_hal_pwrseqcmdparsing(): "
 					 "PWR_CMD_END\n" );
 				return true;


### PR DESCRIPTION
This pull request fixes compilation errors caused by leftover calls to `RT_TRACE`, which has been obsoleted in favor of `rtl_dbg`.

Closes #153, closes #155, closes #157, closes #159.
